### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/src/connectClient/initiator/MewConnectInitiator.js
+++ b/src/connectClient/initiator/MewConnectInitiator.js
@@ -197,13 +197,8 @@ export default class MewConnectInitiator extends MewConnectCommon {
         this.connId +
         ':name=' +
         dapp.replace(/^www\./, '');
-      if (dapp.includes('myetherwallet.com')) {
-        qrCodeString =
-          this.version + separator + privateKey + separator + this.connId;
-      } else if (dapp.includes('mewbuilds.com')) {
-        qrCodeString =
-          this.version + separator + privateKey + separator + this.connId;
-      } else if (dapp.includes('localhost')) {
+      const allowedHosts = ['myetherwallet.com', 'www.myetherwallet.com', 'mewbuilds.com', 'www.mewbuilds.com', 'localhost'];
+      if (allowedHosts.includes(dapp)) {
         qrCodeString =
           this.version + separator + privateKey + separator + this.connId;
       }


### PR DESCRIPTION
Potential fix for [https://github.com/melissamforbs/MEWconnect-web-client/security/code-scanning/6](https://github.com/melissamforbs/MEWconnect-web-client/security/code-scanning/6)

To fix the issue, we need to replace the substring check (`dapp.includes('mewbuilds.com')`) with a more secure method that validates the hostname against a whitelist of allowed hostnames. This can be achieved by comparing `dapp` directly to a list of allowed hostnames or subdomains. The `URL` API can be used to parse and validate the hostname if needed.

Specifically:
1. Define a whitelist of allowed hostnames (e.g., `['mewbuilds.com', 'www.mewbuilds.com']`).
2. Replace the `includes` checks with a validation that ensures `dapp` matches one of the allowed hostnames exactly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
